### PR TITLE
Use stream API to save to writable file handles

### DIFF
--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -155,8 +155,8 @@ class SB3Downloader extends React.Component {
                 }
             });
 
-            // Buffer repeated small messages into one big message to improve performance of write() later.
-            const MIN_BUFFER_SIZE = 65536;
+            // Buffer small messages into one bigger message to improve performance of write() later.
+            const MIN_BUFFER_SIZE = 1024 * 256;
             const queuedChunks = [];
             // eslint-disable-next-line no-undef
             const bufferTransformer = new TransformStream({

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -22,6 +22,33 @@ const getProjectTitleFromFilename = fileInputFilename => {
 };
 
 /**
+ * @param {Uint8Array[]} arrays List of byte arrays
+ * @returns {number} Total length of the arrays
+ */
+const getLengthOfByteArrays = arrays => {
+    let length = 0;
+    for (let i = 0; i < arrays.length; i++) {
+        length += arrays[i].byteLength;
+    }
+    return length;
+};
+
+/**
+ * @param {Uint8Array[]} arrays List of byte arrays
+ * @returns {Uint8Array} One big array containing all of the little arrays in order.
+ */
+const concatenateByteArrays = arrays => {
+    const totalLength = getLengthOfByteArrays(arrays);
+    const newArray = new Uint8Array(totalLength);
+    let p = 0;
+    for (let i = 0; i < arrays.length; i++) {
+        newArray.set(arrays[i], p);
+        p += arrays[i].byteLength;
+    }
+    return newArray;
+};
+
+/**
  * Project saver component passes a downloadProject function to its child.
  * It expects this child to be a function with the signature
  *     function (downloadProject, props) {}
@@ -98,16 +125,70 @@ class SB3Downloader extends React.Component {
         if (!this.props.canSaveProject) {
             return;
         }
-        // Obtain the writable very early, otherwise browsers won't give us the handle when we ask.
-        const writable = await FileSystemAPI.createWritable(handle);
+
+        const writable = await handle.createWritable();
         try {
             this.startedSaving();
-            const content = await this.props.saveProjectSb3();
-            await FileSystemAPI.writeToWritable(writable, content);
+
+            // Projects can be very large, so we'll utilize JSZip's stream API to avoid having the
+            // entire sb3 in memory at the same time.
+            const jszipStream = this.props.saveProjectSb3Stream();
+            const zipStream = new ReadableStream({
+                start: controller => {
+                    jszipStream.on('data', data => {
+                        controller.enqueue(data);
+                        if (controller.desiredSize <= 0) {
+                            // Note that JSZip will keep sending some data after you ask it to pause.
+                            jszipStream.pause();
+                        }
+                    });
+                    jszipStream.on('end', () => {
+                        controller.close();
+                    });
+                    jszipStream.resume();
+                },
+                pull: () => {
+                    jszipStream.resume();
+                },
+                cancel: () => {
+                    jszipStream.pause();
+                }
+            });
+
+            // Buffer repeated small messages into one big message to improve performance of write() later.
+            const MIN_BUFFER_SIZE = 65536;
+            const queuedChunks = [];
+            // eslint-disable-next-line no-undef
+            const bufferTransformer = new TransformStream({
+                transform: (chunk, controller) => {
+                    queuedChunks.push(chunk);
+
+                    const currentSize = getLengthOfByteArrays(queuedChunks);
+                    if (currentSize >= MIN_BUFFER_SIZE) {
+                        const newArray = concatenateByteArrays(queuedChunks);
+                        controller.enqueue(newArray);
+                        queuedChunks.length = 0;
+                    }
+                },
+                flush: controller => {
+                    const newArray = concatenateByteArrays(queuedChunks);
+                    if (newArray.byteLength) {
+                        controller.enqueue(newArray);
+                    }
+                }
+            });
+
+            const fileStream = new WritableStream({
+                write: chunk => writable.write(chunk)
+            });
+
+            await zipStream
+                .pipeThrough(bufferTransformer)
+                .pipeTo(fileStream);
+
             this.finishedSaving();
         } finally {
-            // Always close the handle regardless of errors.
-            await FileSystemAPI.closeWritable(writable);
+            await writable.close();
         }
     }
     handleSaveError (e) {
@@ -157,6 +238,7 @@ SB3Downloader.propTypes = {
     onSaveFinished: PropTypes.func,
     projectFilename: PropTypes.string,
     saveProjectSb3: PropTypes.func,
+    saveProjectSb3Stream: PropTypes.func,
     canSaveProject: PropTypes.bool,
     onSetFileHandle: PropTypes.func,
     onSetProjectTitle: PropTypes.func,
@@ -172,6 +254,7 @@ SB3Downloader.defaultProps = {
 const mapStateToProps = state => ({
     fileHandle: state.scratchGui.tw.fileHandle,
     saveProjectSb3: state.scratchGui.vm.saveProjectSb3.bind(state.scratchGui.vm),
+    saveProjectSb3Stream: state.scratchGui.vm.saveProjectSb3Stream.bind(state.scratchGui.vm),
     canSaveProject: getIsShowingProject(state.scratchGui.projectState.loadingState),
     projectFilename: getProjectFilename(state.scratchGui.projectTitle, projectTitleInitialState)
 });

--- a/src/lib/tw-filesystem-api.js
+++ b/src/lib/tw-filesystem-api.js
@@ -28,21 +28,8 @@ const showOpenFilePicker = async () => {
     return handle;
 };
 
-const createWritable = handle => handle.createWritable();
-
-const closeWritable = async writable => {
-    await writable.close();
-};
-
-const writeToWritable = async (writable, content) => {
-    await writable.write(content);
-};
-
 export default {
     available,
     showOpenFilePicker,
-    showSaveFilePicker,
-    createWritable,
-    closeWritable,
-    writeToWritable
+    showSaveFilePicker
 };


### PR DESCRIPTION
Using API introduced by https://github.com/TurboWarp/scratch-vm/pull/113, when saving files to writable file handles, we can stream it to disk instead of storing the entire project in memory at once

This will allow us to resolve https://github.com/TurboWarp/desktop/issues/554