### PR TITLE
Wrap scratch-paint with error boundary

### DIFF
--- a/src/containers/paint-editor-wrapper.jsx
+++ b/src/containers/paint-editor-wrapper.jsx
@@ -4,6 +4,7 @@ import bindAll from 'lodash.bindall';
 import VM from 'scratch-vm';
 import PaintEditor from '../lib/tw-scratch-paint';
 import {inlineSvgFonts} from 'scratch-svg-renderer';
+import ErrorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
 
 import {connect} from 'react-redux';
 
@@ -101,6 +102,6 @@ const mapStateToProps = (state, {selectedCostumeIndex}) => {
     };
 };
 
-export default connect(
+export default ErrorBoundaryHOC('paint')(connect(
     mapStateToProps
-)(PaintEditorWrapper);
+)(PaintEditorWrapper));


### PR DESCRIPTION
even if paint is broken, make sure people can still export costumes

paint crashes typically get it permanently stuck in a bad state -- would be best if we could also fix those?