### PR TITLE
Prune the list of trusted fetch origins

### DIFF
--- a/src/containers/tw-security-manager.jsx
+++ b/src/containers/tw-security-manager.jsx
@@ -41,12 +41,6 @@ const fetchOriginsTrustedByUser = new Set();
  * @returns {boolean} True if the URL is part of the builtin set of URLs to always trust fetching from.
  */
 const isAlwaysTrustedForFetching = parsed => (
-    // Note that the regexes here don't need to be perfect. It's okay if we let extensions try to fetch
-    // resources from eg. GitHub Pages domains that aren't actually valid usernames. They'll just get
-    // a network error.
-    // URL parsing will always convert the parsed origin to lowercase, so we don't need case
-    // insensitivity here.
-
     // If we would trust loading an extension from here, we can trust loading resources too.
     isTrustedExtension(parsed.href) ||
 
@@ -55,29 +49,8 @@ const isAlwaysTrustedForFetching = parsed => (
     parsed.origin.endsWith('.turbowarp.org') ||
     parsed.origin.endsWith('.turbowarp.xyz') ||
 
-    // GitHub
-    parsed.origin === 'https://raw.githubusercontent.com' ||
-    parsed.origin === 'https://api.github.com' ||
-    parsed.origin.endsWith('.github.io') ||
-
-    // GitLab
-    parsed.origin === 'https://gitlab.com' ||
-    parsed.origin.endsWith('.gitlab.io') ||
-
-    // BitBucket
-    parsed.origin.endsWith('.bitbucket.io') ||
-
-    // Itch
-    parsed.origin.endsWith('.itch.io') ||
-
-    // GameJolt
-    parsed.origin === 'https://api.gamejolt.com' ||
-
-    // httpbin
-    parsed.origin === 'https://httpbin.org' ||
-
-    // ScratchDB
-    parsed.origin === 'https://scratchdb.lefty.one'
+    // GitHub's raw downloads can't redirect to untrusted places, but GitHub Pages can.
+    parsed.origin === 'https://raw.githubusercontent.com'
 );
 
 /**


### PR DESCRIPTION
GitHub, GitLab, and Bitbucket pages allow redirects to untrusted sources. Itch and GameJolt really shouldn't have been on this list in the first place.