### PR TITLE
Use asset host for loading fonts

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -19,7 +19,7 @@ class Storage extends ScratchStorage {
             this.getProjectUpdateConfig.bind(this)
         );
         this.addWebStore(
-            [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound],
+            [this.AssetType.ImageVector, this.AssetType.ImageBitmap, this.AssetType.Sound, this.AssetType.Font],
             this.getAssetGetConfig.bind(this),
             // We set both the create and update configs to the same method because
             // storage assumes it should update if there is an assetId, but the


### PR DESCRIPTION
Closes #1034 

### Resolves

- Resolves #1034 

### Proposed Changes

It adds `this.AssetType.Font` to the configuration of `this.addWebStore,` which will make it attempt to load font files from the file

### Reason for Changes

Some websites' backends allow users to upload font files, so if the work contains font files, they will attempt to read them. If the website does not support this feature, font files will not appear in the artwork

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [x] Chrome
