### PR TITLE
Experiment with counting views (no displaying yet)

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -37,6 +37,7 @@ import TWRestorePointManager from '../../containers/tw-restore-point-manager.jsx
 import TWFontsModal from '../../containers/tw-fonts-modal.jsx';
 import TWUnknownPlatformModal from '../../containers/tw-unknown-platform-modal.jsx';
 import TWInvalidProjectModal from '../../containers/tw-invalid-project-modal.jsx';
+import TWWindChimeSubmitter from '../../containers/tw-windchime-submitter.jsx';
 
 import {STAGE_SIZE_MODES, FIXED_WIDTH, UNCONSTRAINED_NON_STAGE_WIDTH} from '../../lib/layout-constants';
 import {resolveStageSize} from '../../lib/screen-utils';
@@ -186,6 +187,7 @@ const GUIComponent = props => {
             <React.Fragment>
                 <TWSecurityManager securityManager={securityManager} />
                 <TWRestorePointManager />
+                <TWWindChimeSubmitter isEmbedded={isEmbedded} />
                 {usernameModalVisible && <TWUsernameModal />}
                 {settingsModalVisible && <TWSettingsModal />}
                 {customExtensionModalVisible && <TWCustomExtensionModal />}

--- a/src/containers/tw-windchime-submitter.jsx
+++ b/src/containers/tw-windchime-submitter.jsx
@@ -43,7 +43,7 @@ class TWWindchimeSubmitter extends React.Component {
         fetch(ENDPOINT, {
             method: 'PUT',
             body: JSON.stringify({
-                resource: this.props.projectId,
+                resource: `scratch/${this.props.projectId}`,
                 event: this.props.isEmbedded ? 'view/embed' : 'view/index'
             }),
             headers: {

--- a/src/containers/tw-windchime-submitter.jsx
+++ b/src/containers/tw-windchime-submitter.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+import log from '../lib/log';
+
+const ENDPOINT = 'https://windchimes.turbowarp.org/api/chime';
+const OPT_OUT_KEY = 'tw:windchime_opt_out';
+const submittedThisSession = new Set();
+
+const isOptedOut = () => {
+    try {
+        if (localStorage.getItem(OPT_OUT_KEY) === 'true') {
+            return true;
+        }
+    } catch (e) {
+        // ignore
+    }
+
+    // These headers are really intended to be about third-parties so we don't need to follow them,
+    // but if someone has these set, it's good to assume that they would opt out if given the choice.
+    // So we'll just respect that preemptively.
+    return navigator.globalPrivacyControl === 'true' || navigator.doNotTrack === '1';
+};
+
+class TWWindchimeSubmitter extends React.Component {
+    componentDidUpdate (prevProps) {
+        if (
+            (this.props.isRunning && !prevProps.isRunning) &&
+            this.props.projectId
+        ) {
+            this.submit();
+        }
+    }
+
+    submit () {
+        if (isOptedOut() || submittedThisSession.has(this.props.projectId)) {
+            return;
+        }
+
+        submittedThisSession.add(this.props.projectId);
+
+        fetch(ENDPOINT, {
+            method: 'PUT',
+            body: JSON.stringify({
+                resource: this.props.projectId,
+                event: this.props.isEmbedded ? 'view/embed' : 'view/index'
+            }),
+            headers: {
+                'content-type': 'application/json'
+            }
+        })
+            .then(res => {
+                if (!res.ok) {
+                    log.error('Windchime request got status', res.status);
+                }
+            })
+            .catch(err => {
+                log.error('Windchime request failed', err);
+            });
+    }
+
+    render () {
+        // No visible components.
+        return null;
+    }
+}
+
+TWWindchimeSubmitter.propTypes = {
+    isEmbedded: PropTypes.bool.isRequired,
+    isRunning: PropTypes.bool.isRequired,
+    projectId: PropTypes.string.isRequired
+};
+
+const mapStateToProps = state => ({
+    isRunning: state.scratchGui.vmStatus.running,
+    projectId: state.scratchGui.projectState.projectId
+});
+
+const mapDispatchToProps = () => ({});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(TWWindchimeSubmitter);

--- a/src/containers/tw-windchime-submitter.jsx
+++ b/src/containers/tw-windchime-submitter.jsx
@@ -9,8 +9,9 @@ const submittedThisSession = new Set();
 
 const isOptedOut = () => {
     try {
-        if (localStorage.getItem(OPT_OUT_KEY) === 'true') {
-            return true;
+        const local = localStorage.getItem(OPT_OUT_KEY);
+        if (local !== null) {
+            return local === 'true';
         }
     } catch (e) {
         // ignore

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -73,9 +73,9 @@
                         }
                     };
                     const checkbox = document.querySelector('.windchimes-optout');
-                    checkbox.checked = isOptedOut();
+                    checkbox.checked = !isOptedOut();
                     checkbox.addEventListener('change', (e) => {
-                        setOptedOut(e.target.checked);
+                        setOptedOut(!e.target.checked);
                     });
                 })();
             </script>

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -33,15 +33,60 @@
 
         <main>
             <!-- UPDATE THIS WHEN MAKING CONTENT CHANGES -->
-            <p><i>Updated May 24, 2024</i></p>
+            <p><i>Updated September 27, 2025</i></p>
 
-            <p><b>The TurboWarp project respects your privacy.</b> Every website says this, but we mean it: We aren't interested in your data. In the interest of full transparency, this document lists every place where your data might be collected or shared:</p>
+            <p>The TurboWarp project respects your privacy. We're an open source project ran by volunteers. For transparency, this page lists all the places in TurboWarp where we or a third-party receive your data and how your data is handled.</p>
+
+            <h2>Abuse</h2>
+            <p>When a service is being abused, we may take measures to collect information to protect the service. For example, we could log IP addresses making excessive amounts of requests. We strive to do this carefully so that no one is caught in the crossfire. Data is kept only as long as needed to stop the abuse.</p>
+
+            <h2>turbowarp.org</h2>
+            <p>A randomly generated username may be saved in your browser. You can replace this with a custom username. Randomly generated usernames are anonymized by removing the random numbers before being sent to any cloud variable server.</p>
+            <p>When you start a project that is loaded from Scratch, this may be logged so that a view counter can be incremented over time. Views are anonymous and can not be tied back to any user. You can prevent your views from being counted by unchecking the box below. This checkbox will not affect your ability to see view counts.</p>
+            <p>
+                <label>
+                    <input type="checkbox" class="windchimes-optout">
+                    Allow counting my views
+                </label>
+            </p>
+            <script>
+                (function() {
+                    const isOptedOut = () => {
+                        try {
+                            const local = localStorage.getItem('tw:windchime_opt_out');
+                            if (local !== null) {
+                                return local === 'true';
+                            }
+                        } catch (e) {
+                            // ignore
+                        }
+                        // These headers are really intended to be about third-parties so we don't need to follow them,
+                        // but if someone has these set, it's good to assume that they would opt out if given the choice.
+                        // So we'll just respect that preemptively.
+                        return navigator.globalPrivacyControl === 'true' || navigator.doNotTrack === '1';
+                    };
+                    const setOptedOut = optedOut => {
+                        try {
+                            localStorage.setItem('tw:windchime_opt_out', optedOut);
+                        } catch (e) {
+                            // ignore
+                        }
+                    };
+                    const checkbox = document.querySelector('.windchimes-optout');
+                    checkbox.checked = isOptedOut();
+                    checkbox.addEventListener('change', (e) => {
+                        setOptedOut(e.target.checked);
+                    });
+                })();
+            </script>
 
             <h2>Loading projects</h2>
             <p>When you load a project from another website, you are subject to the privacy practices of that website. For example, when loading projects from Scratch, you are subject to the <a href="https://scratch.mit.edu/privacy_policy">Scratch privacy policy</a>. When loading projects from Scratch specifically, the project ID will also be shared with TurboWarp as part of Scratch's API does not allow direct access. We may briefly log the project ID for caching.</p>
 
-            <h2>Running projects</h2>
-            <p>When connecting to our cloud variable servers, the project ID and username may be logged for 14 days. Data in cloud variables is sent to anyone else connected at the same time. Custom cloud variable servers are outside of our control.</p>
+            <h2>Cloud variables</h2>
+            <p>When connecting to our cloud variable servers, the project ID and username may be logged for 14 days. Data in cloud variables is public and sent to anyone else connected at the same time. Custom cloud variable servers are outside of our control.</p>
+
+            <h2>Extensions</h2>
             <p>Some extensions must communicate with external APIs to function. For example, the translate and text-to-speech extensions rely on the Scratch API, which is covered by the <a href="https://scratch.mit.edu/privacy_policy">Scratch privacy policy</a>. To improve performance, some extensions access TurboWarp's APIs instead where both the request (for example, the text being translated) and the result after forwarding to Scratch (for example, the translated version of the text) may be cached.</p>
             <p>Most extensions on the <a href="https://extensions.turbowarp.org/">official extension gallery</a> will ask for permission when the project attempts to use the extension to access an untrusted website, however we cannot guarantee this is 100% reliable.</p>
             <p>When loading a custom extension from a place other than the official gallery such as a URL or file on your computer, the editor will ask for permission to load the extension. If you approve this dialog, the extension can bypass the permission dialogs that official extensions show.</p>
@@ -51,9 +96,6 @@
 
             <h2>Aggregated data</h2>
             <p>We may log anonymous aggregated data such as how many people use a certain site per day.</p>
-
-            <h2>turbowarp.org</h2>
-            <p>A randomly generated username may be saved in your browser. You can replace this with a custom username. Randomly generated usernames are anonymized (the random part is removed) before being sent to any cloud variable server.</p>
 
             <h2>TurboWarp Desktop</h2>
             <p><a href="https://desktop.turbowarp.org/">TurboWarp Desktop</a> may make requests to check for updates. This can be disabled by pressing "Settings" then "Desktop Settings".</p>


### PR DESCRIPTION
This is only the counting. We'll display them later, once we're somewhat confident in the data.

 - A new backend service for view counting: [windchimes](https://windchimes.turbowarp.org/)
 - To prevent one person submitting thousands of fake views in a very short time, there are some anti-abuse mechanisms. They're based on a hash of a combination of at least IP + a random frequently-changing salt so that user data doesn't stay in memory longer than needed.
 - Once views are committed, all that gets stored is a total count and a daily count. Impossible to tie back to an individual.
 - Views through embeds are counted separately internally. Later on can decide how to display that.
 - View counting opt-out available in the privacy policy page