### PR TITLE
fix library searching with 'object' term

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -229,7 +229,13 @@ class LibraryComponent extends React.Component {
                     }
                 }
                 if (dataItem.description) {
-                    search.push(dataItem.description);
+                    if (typeof dataItem.description === 'string') {
+                        search.push(dataItem.description);
+                    } else {
+                        search.push(this.props.intl.formatMessage(dataItem.description.props, {
+                            APP_NAME
+                        }));
+                    }
                 }
                 return search
                     .join('\n')


### PR DESCRIPTION
the `description` key on library items wasn't being checked if it was a formatted message when searching, so in the extension library pretty much everything except stuff loaded from the turbowarp extension gallery would show if you searched for something like `object`, or more specifically `[object Object]` (since the formatted message object was being stringified)

| Before | After |
| ----------- | ----------- |
|<img width="1920" height="945" alt="{31C35A04-EF78-4163-850E-68CE5BD58969}" src="https://github.com/user-attachments/assets/833f1c52-93ba-4742-9231-9b7306784035" />|<img width="1920" height="943" alt="{4836C45F-91A7-4FAA-89DD-133739C22CF3}" src="https://github.com/user-attachments/assets/a197bde2-51a4-4505-a667-d8d7d7dda3c8" />|