### PR TITLE
Added support for more argument types for dynamic extension blocks

### DIFF
--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -89,7 +89,6 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
         }
 
         // Layout block arguments
-        // TODO handle ArgumentType.IMAGE
         // TODO handle E/C Blocks
         const blockText = blockInfo.text;
         const args = [];
@@ -109,6 +108,15 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
                 break;
             case ArgumentType.BOOLEAN:
                 args.push({type: 'input_value', name: argName, check: 'Boolean'});
+                break;
+            case ArgumentType.IMAGE:
+                args.push({
+                    type: 'field_image',
+                    src: arg.dataURI || '',
+                    width: 24,
+                    height: 24,
+                    flip_rtl: arg.flipRTL || false
+                });
                 break;
             }
             return `%${++argCount}`;

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -89,8 +89,8 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
         }
 
         // Layout block arguments
-        // TODO handle E/C Blocks
         // TODO handle ArgumentType.IMAGE
+        // TODO handle E/C Blocks
         const blockText = blockInfo.text;
         const args = [];
         let argCount = 0;
@@ -98,23 +98,17 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
             const arg = blockInfo.arguments[argName];
             switch (arg.type) {
             case ArgumentType.STRING:
-                args.push({type: 'input_value', name: argName});
-                break;
-            case ArgumentType.BOOLEAN:
-                args.push({type: 'input_value', name: argName, check: 'Boolean'});
-                break;
             case ArgumentType.NUMBER:
             case ArgumentType.ANGLE:
             case ArgumentType.MATRIX:
             case ArgumentType.NOTE:
-                args.push({type: 'input_value', name: argName, check: 'Number'});
-                break;
             case ArgumentType.COLOR:
-                args.push({type: 'input_value', name: argName, check: 'Colour'});
-                break;
             case ArgumentType.COSTUME:
             case ArgumentType.SOUND:
-                args.push({type: 'input_value', name: argName, check: 'String'});
+                args.push({type: 'input_value', name: argName});
+                break;
+            case ArgumentType.BOOLEAN:
+                args.push({type: 'input_value', name: argName, check: 'Boolean'});
                 break;
             }
             return `%${++argCount}`;

--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -90,6 +90,7 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
 
         // Layout block arguments
         // TODO handle E/C Blocks
+        // TODO handle ArgumentType.IMAGE
         const blockText = blockInfo.text;
         const args = [];
         let argCount = 0;
@@ -101,6 +102,19 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
                 break;
             case ArgumentType.BOOLEAN:
                 args.push({type: 'input_value', name: argName, check: 'Boolean'});
+                break;
+            case ArgumentType.NUMBER:
+            case ArgumentType.ANGLE:
+            case ArgumentType.MATRIX:
+            case ArgumentType.NOTE:
+                args.push({type: 'input_value', name: argName, check: 'Number'});
+                break;
+            case ArgumentType.COLOR:
+                args.push({type: 'input_value', name: argName, check: 'Colour'});
+                break;
+            case ArgumentType.COSTUME:
+            case ArgumentType.SOUND:
+                args.push({type: 'input_value', name: argName, check: 'String'});
                 break;
             }
             return `%${++argCount}`;


### PR DESCRIPTION
### Resolves

- Resolves part of https://github.com/TurboWarp/scratch-gui/issues/1156

### Proposed Changes

Adds cases for handling other ArgumentTypes for dynamic extension blocks. Previously, creating blocks with isDynamic = true which contained argument types which weren't STRING or BOOLEAN raised an exception in interpolation which broke the editor (Message index %1 out of range). Now, the blocks are instantiated properly. 

### Reason for Changes

I don't know if more work is needed for full support, but I think it's better for the program not to crash at least, and I haven't seen any immediate issues.

### Test Coverage

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
