### PR TITLE
Support `project_title` parameter

### DIFF
--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -54,7 +54,6 @@ const TitledHOC = function (WrappedComponent) {
                 const urlTitle = typeof URLSearchParams !== 'undefined' &&
                     new URLSearchParams(location.search).get('project_title');
                 if (urlTitle) {
-                    // a title provided via the URL is a real title, not the default
                     newTitle = urlTitle;
                 } else {
                     newTitle = this.props.intl.formatMessage(messages.defaultProjectTitle);

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -51,7 +51,10 @@ const TitledHOC = function (WrappedComponent) {
             let newTitle = requestedTitle;
             let isDefault = false;
             if (newTitle === null || typeof newTitle === 'undefined') {
-                newTitle = this.props.intl.formatMessage(messages.defaultProjectTitle);
+                newTitle = (
+                    typeof URLSearchParams !== 'undefined' &&
+                    new URLSearchParams(location.search).get('project_title')
+                ) || this.props.intl.formatMessage(messages.defaultProjectTitle);
                 isDefault = true;
             }
             this.props.onChangedProjectTitle(newTitle, isDefault);

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -33,8 +33,8 @@ const TitledHOC = function (WrappedComponent) {
             // if project is a new default project, and has loaded,
             if (this.props.isShowingWithoutId && prevProps.isAnyCreatingNewState) {
                 // reset title to default
-                const defaultProjectTitle = this.handleReceivedProjectTitle();
-                this.props.onUpdateProjectTitle(defaultProjectTitle, true);
+                const {title, isDefault} = this.handleReceivedProjectTitle();
+                this.props.onUpdateProjectTitle(title, isDefault);
             }
             // if the projectTitle hasn't changed, but the reduxProjectTitle
             // HAS changed, we need to report that change to the projectTitle's owner
@@ -51,14 +51,21 @@ const TitledHOC = function (WrappedComponent) {
             let newTitle = requestedTitle;
             let isDefault = false;
             if (newTitle === null || typeof newTitle === 'undefined') {
-                newTitle = (
-                    typeof URLSearchParams !== 'undefined' &&
-                    new URLSearchParams(location.search).get('project_title')
-                ) || this.props.intl.formatMessage(messages.defaultProjectTitle);
-                isDefault = true;
+                const urlTitle = typeof URLSearchParams !== 'undefined' &&
+                    new URLSearchParams(location.search).get('project_title');
+                if (urlTitle) {
+                    // a title provided via the URL is a real title, not the default
+                    newTitle = urlTitle;
+                } else {
+                    newTitle = this.props.intl.formatMessage(messages.defaultProjectTitle);
+                    isDefault = true;
+                }
             }
             this.props.onChangedProjectTitle(newTitle, isDefault);
-            return newTitle;
+            return {
+                title: newTitle,
+                isDefault
+            };
         }
         render () {
             const {

--- a/test/integration/project-state.test.js
+++ b/test/integration/project-state.test.js
@@ -42,11 +42,4 @@ describe('Project state', () => {
         // project title should be default again
         await clickXpath(`//input[@value="${defaultProjectTitle}"]`);
     });
-
-    test('project_title parameter', async () => {
-        const title = `title${Date.now()}`;
-        const editor_uri = path.join(uri, './editor.html');
-        await loadUri(`${editor_uri}?project_title=${title}`);
-        await clickXpath(`//input[@value="${title}"]`);
-    });
 });

--- a/test/integration/project-state.test.js
+++ b/test/integration/project-state.test.js
@@ -45,7 +45,8 @@ describe('Project state', () => {
 
     test('project_title parameter', async () => {
         const title = `title${Date.now()}`;
-        await loadUri(`${uri}?project_title=${title}`);
+        const editor_uri = path.join(uri, './editor.html');
+        await loadUri(`${editor_uri}?project_title=${title}`);
         await clickXpath(`//input[@value="${title}"]`);
     });
 });

--- a/test/integration/project-state.test.js
+++ b/test/integration/project-state.test.js
@@ -42,4 +42,10 @@ describe('Project state', () => {
         // project title should be default again
         await clickXpath(`//input[@value="${defaultProjectTitle}"]`);
     });
+
+    test('project_title parameter', async () => {
+        const title = `title${Date.now()}`;
+        await loadUri(`${uri}?project_title=${title}`);
+        await clickXpath(`//input[@value="${title}"]`);
+    });
 });


### PR DESCRIPTION
Fix #1002

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #1002

### Proposed Changes

Support `project_title` parameter.

Do not use together with a regular project ID.

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

See `test/integration/project-state.test.js`

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
