### PR TITLE
Let dragging monitors to the edge in small Stage

### DIFF
--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -17,30 +17,28 @@ const MonitorList = props => (
             ...stageSizeToTransform(props.stageSize)
         }}
     >
-        <Box>
-            {props.monitors && props.monitors.valueSeq().filter(m => m.visible)
-                .map(monitorData => (
-                    <Monitor
-                        draggable={props.draggable}
-                        height={monitorData.height}
-                        id={monitorData.id}
-                        isDiscrete={monitorData.isDiscrete}
-                        key={monitorData.id}
-                        max={monitorData.sliderMax}
-                        min={monitorData.sliderMin}
-                        mode={monitorData.mode}
-                        opcode={monitorData.opcode}
-                        params={monitorData.params}
-                        spriteName={monitorData.spriteName}
-                        targetId={monitorData.targetId}
-                        value={monitorData.value}
-                        width={monitorData.width}
-                        x={monitorData.x}
-                        y={monitorData.y}
-                        onDragEnd={props.onMonitorChange}
-                    />
-                ))}
-        </Box>
+        {props.monitors && props.monitors.valueSeq().filter(m => m.visible)
+            .map(monitorData => (
+                <Monitor
+                    draggable={props.draggable}
+                    height={monitorData.height}
+                    id={monitorData.id}
+                    isDiscrete={monitorData.isDiscrete}
+                    key={monitorData.id}
+                    max={monitorData.sliderMax}
+                    min={monitorData.sliderMin}
+                    mode={monitorData.mode}
+                    opcode={monitorData.opcode}
+                    params={monitorData.params}
+                    spriteName={monitorData.spriteName}
+                    targetId={monitorData.targetId}
+                    value={monitorData.value}
+                    width={monitorData.width}
+                    x={monitorData.x}
+                    y={monitorData.y}
+                    onDragEnd={props.onMonitorChange}
+                />
+            ))}
     </Box>
 );
 

--- a/src/components/monitor-list/monitor-list.jsx
+++ b/src/components/monitor-list/monitor-list.jsx
@@ -10,16 +10,14 @@ import styles from './monitor-list.css';
 const MonitorList = props => (
     <Box
         // Use static `monitor-overlay` class for bounds of draggables
-        className={classNames(styles.monitorList, 'monitor-overlay')}
+        className={classNames(styles.monitorList, 'monitor-overlay', styles.monitorListScaler)}
         style={{
-            width: props.stageSize.width,
-            height: props.stageSize.height
+            width: props.stageSize.widthDefault,
+            height: props.stageSize.heightDefault,
+            ...stageSizeToTransform(props.stageSize)
         }}
     >
-        <Box
-            className={styles.monitorListScaler}
-            style={stageSizeToTransform(props.stageSize)}
-        >
+        <Box>
             {props.monitors && props.monitors.valueSeq().filter(m => m.visible)
                 .map(monitorData => (
                     <Monitor


### PR DESCRIPTION
### Resolves

upstream bug
https://github.com/scratchfoundation/scratch-gui/issues/2949

### Proposed Changes

Instead of changing the width/height of the dragging bounds, use the CSS transform on it.

### Reason for Changes

With the transform applied to the things inside the smaller bounds, CSS does the word-wrapping for the small bounds and shrinks that.
With the transform applied to the original bounds, it does the word-wrapping for the original bounds and shrinks that.
I think react-draggable tries to get the same bounds that CSS uses for the word-wrapping.

### Test Coverage

I've tried it out and it seems to work, although in Edge it showed a CORS error when I first tried to go into the editor but I don't think that was caused by my changes

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [X] Chrome 
 * [ ] Firefox 
 * [X] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


I've copied the changes from https://github.com/scratchfoundation/scratch-editor/pull/314, but I think this is allowed because I made that.
I didn't copy the second half because that part is a bit weird, but if you want I can copy that, too