### PR TITLE
Add support for ctrl key in editor arrow key incrementation

### DIFF
--- a/src/addons/addons/editor-number-arrow-keys/_manifest_entry.js
+++ b/src/addons/addons/editor-number-arrow-keys/_manifest_entry.js
@@ -153,7 +153,54 @@ const manifest = {
           "useCustom": true
         }
       }
-    },
+      },
+      {
+        "dynamic": true,
+        "name": "Change on Ctrl+Key (Cmd on Mac)",
+        "id": "ctrl",
+        "type": "select",
+        "default": "hundredth",
+        "potentialValues": [
+          {
+            "id": "none",
+            "name": "None"
+          },
+          {
+            "id": "hundredth",
+            "name": "0.01"
+          },
+          {
+            "id": "tenth",
+            "name": "0.1"
+          },
+          {
+            "id": "one",
+            "name": "1"
+          },
+          {
+            "id": "ten",
+            "name": "10"
+          }
+        ],
+        "if": {
+          "settings": {
+            "useCustom": false
+          }
+        }
+      },
+      {
+        "dynamic": true,
+        "name": "Change on Ctrl+Key (Cmd on Mac)",
+        "id": "ctrlCustom",
+        "type": "untranslated",
+        "default": "0.01",
+        "max": 8,
+        "if": {
+          "settings": {
+            "useCustom": true
+          }
+        }
+      },
     {
       "dynamic": true,
       "name": "Use custom values",
@@ -169,6 +216,10 @@ const manifest = {
     },
     {
       "name": "World_Languages"
+    },
+    {
+      "name": "kalyzu",
+      "link": "https://github.com/kalyzu"
     }
   ],
   "dynamicDisable": true

--- a/src/addons/addons/editor-number-arrow-keys/userscript.js
+++ b/src/addons/addons/editor-number-arrow-keys/userscript.js
@@ -1,4 +1,5 @@
 export default async function ({ addon }) {
+  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
   const settings = {
     none: 0,
     hundredth: 0.01,
@@ -102,13 +103,18 @@ export default async function ({ addon }) {
     // If this is a number input, it will prevent the default browser behavior when pressing up/down in a
     // number input (increase or decrease by 1). If we didn't prevent, the user would be increasing twice.
 
+    // Assign ctrlModifier based on platform
+    const ctrlModifier = isMac ? e.metaKey : e.ctrlKey;
+
     let changeBy = e.key === "ArrowUp" ? 1 : -1;
     if (addon.settings.get("useCustom")) {
-      let settingValue = e.shiftKey
-        ? addon.settings.get("shiftCustom")
-        : e.altKey
-          ? addon.settings.get("altCustom")
-          : addon.settings.get("regularCustom");
+      let settingValue = ctrlModifier
+        ? addon.settings.get("ctrlCustom")
+        : e.shiftKey
+          ? addon.settings.get("shiftCustom")
+          : e.altKey
+            ? addon.settings.get("altCustom")
+            : addon.settings.get("regularCustom");
       if (settingValue === "") settingValue = 0;
       let valueAsFloat = parseFloat(settingValue);
       if (valueAsFloat < 0) valueAsFloat *= -1; // If user typed a negative number, we make it positive
@@ -121,11 +127,13 @@ export default async function ({ addon }) {
         return;
       }
     } else {
-      changeBy *= e.shiftKey
-        ? settings[addon.settings.get("shift")]
-        : e.altKey
-          ? settings[addon.settings.get("alt")]
-          : settings[addon.settings.get("regular")];
+      changeBy *= ctrlModifier
+        ? settings[addon.settings.get("ctrl")]
+        : e.shiftKey
+          ? settings[addon.settings.get("shift")]
+          : e.altKey
+            ? settings[addon.settings.get("alt")]
+            : settings[addon.settings.get("regular")];
     }
 
     const decimalCount = Math.max(amountOfDecimals(e.target.value), amountOfDecimals(changeBy.toString()));


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves: Small enough that it does not need a separate issue

### Proposed Changes

Allows for another option for arrow key incrementation, the Ctrl key.
Logic has been implemented to use `e.metaKey` if the platform is MacOS.

### Reason for Changes

I have found that I need arrow key incrementation for 10, 1, 0.1, _and_ 0.01 at the same time, so I (the 0 experience dev) took it upon myself to add it, not just open an issue.

### Test Coverage

I'm not aware that addons have test scripts, but I can verify that the Ctrl, Shift, Alt, and Regular incrementations work on the below platforms.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Linux (Arch)
 * [x] Chromium
 * [x] Firefox

(Fix was extremely minimal, cross-platform testing was skipped)